### PR TITLE
Add ASGI entrypoint module for FastAPI app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,4 @@
+"""ASGI application entrypoint for the 1A2B FastAPI service."""
+from create_a_1a2b_game import app
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add a thin ASGI entrypoint module that exposes the FastAPI application as `app`
- ensure the project can be started via `uvicorn app:app`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60fb63f30832883fb757342b9df10