### PR TITLE
feat: add zh language toggle and improve accessibility

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -8,8 +8,10 @@
       :root {
         color-scheme: light dark;
         font-family: "Segoe UI", Roboto, sans-serif;
+        font-size: 18px;
         background-color: #f0f4f8;
         color: #1f2933;
+        line-height: 1.6;
       }
 
       body {
@@ -27,6 +29,26 @@
         border-radius: 16px;
         padding: 2.5rem 2rem;
         box-shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
+      }
+
+      .language-toggle {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 1rem;
+      }
+
+      .language-toggle label {
+        font-weight: 600;
+        margin-right: 0.5rem;
+      }
+
+      .language-toggle select {
+        padding: 0.4rem 0.75rem;
+        font-size: 1rem;
+        border: 2px solid #94a3b8;
+        border-radius: 8px;
+        background-color: #fff;
+        color: inherit;
       }
 
       h1 {
@@ -52,7 +74,7 @@
       input[type="text"] {
         flex: 1 1 160px;
         padding: 0.75rem 1rem;
-        font-size: 1rem;
+        font-size: 1.05rem;
         border: 2px solid #94a3b8;
         border-radius: 8px;
         outline: none;
@@ -66,7 +88,7 @@
 
       button {
         padding: 0.75rem 1.4rem;
-        font-size: 1rem;
+        font-size: 1.05rem;
         border: none;
         border-radius: 8px;
         cursor: pointer;
@@ -113,7 +135,7 @@
 
       .history h2 {
         margin-bottom: 0.75rem;
-        font-size: 1.1rem;
+        font-size: 1.15rem;
         color: #0b7285;
       }
 
@@ -131,7 +153,7 @@
         padding: 0.8rem 1rem;
         text-align: center;
         border-bottom: 1px solid #e2e8f0;
-        font-size: 0.95rem;
+        font-size: 1rem;
       }
 
       th {
@@ -158,11 +180,17 @@
   </head>
   <body>
     <main class="game-container">
-      <h1>1A2B Game</h1>
-      <p class="description">
-        Guess the 4-digit secret number with unique digits. The API will tell you
-        how many digits are correct and in the right position (<strong>A</strong>)
-        and how many digits are correct but in the wrong position (<strong>B</strong>).
+      <div class="language-toggle">
+        <label for="language-select" data-i18n="languageLabel">語言</label>
+        <select id="language-select" aria-label="語言切換">
+          <option value="zh" selected data-i18n-option="zh">繁體中文</option>
+          <option value="en" data-i18n-option="en">English</option>
+        </select>
+      </div>
+      <h1 data-i18n="title">1A2B 猜數字遊戲</h1>
+      <p class="description" data-i18n="description">
+        猜出由四個不重複數字組成的秘密數字。系統會告訴你有多少數字
+        <strong>A</strong> 表示位置正確，<strong>B</strong> 表示數字正確但位置不對。
       </p>
       <form id="guess-form">
         <input
@@ -170,27 +198,29 @@
           type="text"
           inputmode="numeric"
           autocomplete="off"
-          placeholder="Enter a 4-digit guess"
-          aria-label="4-digit guess"
+          placeholder="輸入四位數字猜測"
+          aria-label="輸入四位數字"
           required
         />
-        <button type="submit">Submit Guess</button>
-        <button type="button" class="secondary" id="new-game">New Game</button>
+        <button type="submit" data-i18n="submit">送出猜測</button>
+        <button type="button" class="secondary" id="new-game" data-i18n="newGame">
+          新遊戲
+        </button>
       </form>
       <div id="feedback" class="feedback" role="status" aria-live="polite"></div>
       <section class="history" aria-live="polite">
-        <h2>Guess History</h2>
+        <h2 data-i18n="historyTitle">猜測紀錄</h2>
         <table aria-describedby="history-table">
           <thead>
             <tr>
-              <th scope="col">Attempt</th>
-              <th scope="col">Guess</th>
-              <th scope="col">Result</th>
+              <th scope="col" data-i18n="historyAttempt">次數</th>
+              <th scope="col" data-i18n="historyGuess">猜測</th>
+              <th scope="col" data-i18n="historyResult">結果</th>
             </tr>
           </thead>
           <tbody id="history-body">
             <tr id="empty-history">
-              <td colspan="3">No guesses yet. Try your first one!</td>
+              <td colspan="3" data-i18n="historyEmpty">尚無紀錄，先來第一次猜測吧！</td>
             </tr>
           </tbody>
         </table>
@@ -202,16 +232,145 @@
       const guessForm = document.getElementById("guess-form");
       const historyBody = document.getElementById("history-body");
       const emptyHistoryRow = document.getElementById("empty-history");
+      const emptyHistoryCell = document.querySelector(
+        "#empty-history [data-i18n=\"historyEmpty\"]"
+      );
       const newGameButton = document.getElementById("new-game");
+      const languageSelect = document.getElementById("language-select");
+      const languageLabel = document.querySelector("[data-i18n=\"languageLabel\"]");
+      const translationOptions = document.querySelectorAll("[data-i18n-option]");
+      const pageTitleEl = document.querySelector("[data-i18n=\"title\"]");
+      const descriptionEl = document.querySelector("[data-i18n=\"description\"]");
+      const submitButton = document.querySelector("[data-i18n=\"submit\"]");
+      const historyTitleEl = document.querySelector("[data-i18n=\"historyTitle\"]");
+      const historyAttemptEl = document.querySelector("[data-i18n=\"historyAttempt\"]");
+      const historyGuessEl = document.querySelector("[data-i18n=\"historyGuess\"]");
+      const historyResultEl = document.querySelector("[data-i18n=\"historyResult\"]");
 
+      const translations = {
+        zh: {
+          langCode: "zh-Hant",
+          pageTitle: "1A2B 猜數字遊戲",
+          languageLabel: "語言",
+          languageToggleAria: "語言切換",
+          languageOption_zh: "繁體中文",
+          languageOption_en: "English",
+          title: "1A2B 猜數字遊戲",
+          description:
+            "猜出由四個不重複數字組成的秘密數字。系統會告訴你有多少數字 <strong>A</strong> 表示位置正確，<strong>B</strong> 表示數字正確但位置不對。",
+          submit: "送出猜測",
+          newGame: "新遊戲",
+          historyTitle: "猜測紀錄",
+          historyAttempt: "次數",
+          historyGuess: "猜測",
+          historyResult: "結果",
+          historyEmpty: "尚無紀錄，先來第一次猜測吧！",
+          guessPlaceholder: "輸入四位數字猜測",
+          guessAriaLabel: "輸入四位數字",
+          newGameStarted: "已開始新遊戲！請輸入你的第一次猜測。",
+          startGamePrompt: "請先點擊「新遊戲」開始。",
+          validationDigits: "請輸入正好四個數字。",
+          validationUnique: "數字不可重複，請再試一次。",
+          guessContinue: "{a}A{b}B — 繼續加油！",
+          successMessage: "🎉 恭喜！你在 {attempts} 次內猜中答案。",
+          startGameError: "目前無法開始新遊戲。",
+          guessError: "無法評估這次的猜測。",
+          genericError: "發生錯誤，請稍後再試。",
+          "Digits must be unique in secret and guess numbers.":
+            "秘密數字與猜測都必須由不重複的數字組成。",
+          "Both secret_number and guess must be 4 digits long.":
+            "秘密數字與猜測都必須是四位數。",
+        },
+        en: {
+          langCode: "en",
+          pageTitle: "1A2B Game",
+          languageLabel: "Language",
+          languageToggleAria: "Language switch",
+          languageOption_zh: "Chinese (Traditional)",
+          languageOption_en: "English",
+          title: "1A2B Game",
+          description:
+            "Guess the secret four-digit number with unique digits. The system will tell you how many digits are correct and in the right position (<strong>A</strong>) and how many digits are correct but misplaced (<strong>B</strong>).",
+          submit: "Submit Guess",
+          newGame: "New Game",
+          historyTitle: "Guess History",
+          historyAttempt: "Attempt",
+          historyGuess: "Guess",
+          historyResult: "Result",
+          historyEmpty: "No guesses yet. Try your first one!",
+          guessPlaceholder: "Enter a 4-digit guess",
+          guessAriaLabel: "4-digit guess",
+          newGameStarted: "New game started! Enter your first guess.",
+          startGamePrompt: "Click \"New Game\" to start playing.",
+          validationDigits: "Please enter exactly four digits.",
+          validationUnique: "Digits must be unique. Try a different combination.",
+          guessContinue: "{a}A{b}B — keep going!",
+          successMessage: "🎉 Correct! You cracked the code in {attempts} attempts.",
+          startGameError: "Unable to start a new game right now.",
+          guessError: "Unable to evaluate guess.",
+          genericError: "Something went wrong. Please try again.",
+          "Digits must be unique in secret and guess numbers.":
+            "Digits must be unique in secret and guess numbers.",
+          "Both secret_number and guess must be 4 digits long.":
+            "Both secret_number and guess must be 4 digits long.",
+        },
+      };
+
+      let currentLanguage = "zh";
       let secretNumber = "";
       let attemptCounter = 0;
+      let lastFeedback = null;
+
+      function t(key, params = {}) {
+        const dictionary = translations[currentLanguage] || translations.en;
+        const fallbackDictionary = translations.en;
+        const template =
+          (dictionary && dictionary[key]) || fallbackDictionary[key] || "";
+        return template.replace(/\{(\w+)\}/g, (_, token) => {
+          return Object.prototype.hasOwnProperty.call(params, token)
+            ? params[token]
+            : `{${token}}`;
+        });
+      }
+
+      function setFeedback(key, type = "", params = {}) {
+        lastFeedback = { key, type, params };
+        feedbackEl.textContent = t(key, params);
+        feedbackEl.className = ["feedback", type].filter(Boolean).join(" ");
+      }
+
+      function applyTranslations() {
+        const dict = translations[currentLanguage];
+        document.documentElement.lang = dict.langCode;
+        document.title = dict.pageTitle;
+        languageLabel.textContent = dict.languageLabel;
+        languageSelect.setAttribute("aria-label", dict.languageToggleAria);
+        translationOptions.forEach((option) => {
+          const optionKey = option.getAttribute("data-i18n-option");
+          option.textContent = t(`languageOption_${optionKey}`);
+        });
+        languageSelect.value = currentLanguage;
+        pageTitleEl.textContent = dict.title;
+        descriptionEl.innerHTML = dict.description;
+        submitButton.textContent = dict.submit;
+        newGameButton.textContent = dict.newGame;
+        historyTitleEl.textContent = dict.historyTitle;
+        historyAttemptEl.textContent = dict.historyAttempt;
+        historyGuessEl.textContent = dict.historyGuess;
+        historyResultEl.textContent = dict.historyResult;
+        emptyHistoryCell.textContent = dict.historyEmpty;
+        guessInput.placeholder = dict.guessPlaceholder;
+        guessInput.setAttribute("aria-label", dict.guessAriaLabel);
+        if (lastFeedback && translations[currentLanguage][lastFeedback.key]) {
+          setFeedback(lastFeedback.key, lastFeedback.type, lastFeedback.params);
+        }
+      }
 
       async function startNewGame() {
         try {
           const response = await fetch("/secret");
           if (!response.ok) {
-            throw new Error("Failed to start a new game.");
+            throw new Error("startGameError");
           }
 
           const data = await response.json();
@@ -220,23 +379,26 @@
           historyBody.innerHTML = "";
           historyBody.appendChild(emptyHistoryRow);
           emptyHistoryRow.hidden = false;
-          feedbackEl.textContent = "New game started! Enter your first guess.";
-          feedbackEl.className = "feedback";
+          setFeedback("newGameStarted");
           guessInput.value = "";
           guessInput.focus();
         } catch (error) {
-          feedbackEl.textContent = error.message || "Unable to start a new game.";
-          feedbackEl.className = "feedback error";
+          const messageKey = error && error.message;
+          if (messageKey && translations[currentLanguage][messageKey]) {
+            setFeedback(messageKey, "error");
+          } else {
+            setFeedback("genericError", "error");
+          }
         }
       }
 
       function validateGuess(guess) {
         if (!/^\d{4}$/.test(guess)) {
-          return "Please enter exactly four digits.";
+          return "validationDigits";
         }
         const uniqueDigits = new Set(guess);
         if (uniqueDigits.size !== 4) {
-          return "Digits must be unique. Try a different combination.";
+          return "validationUnique";
         }
         return "";
       }
@@ -253,22 +415,29 @@
         const resultCell = document.createElement("td");
         resultCell.textContent = `${a}A${b}B`;
         row.append(attemptCell, guessCell, resultCell);
-        historyBody.appendChild(row);
+
+        const firstExistingRow = Array.from(historyBody.children).find(
+          (child) => child !== emptyHistoryRow
+        );
+
+        if (firstExistingRow) {
+          historyBody.insertBefore(row, firstExistingRow);
+        } else {
+          historyBody.insertBefore(row, emptyHistoryRow);
+        }
       }
 
       guessForm.addEventListener("submit", async (event) => {
         event.preventDefault();
         const guess = guessInput.value.trim();
-        const errorMessage = validateGuess(guess);
-        if (errorMessage) {
-          feedbackEl.textContent = errorMessage;
-          feedbackEl.className = "feedback error";
+        const errorKey = validateGuess(guess);
+        if (errorKey) {
+          setFeedback(errorKey, "error");
           return;
         }
 
         if (!secretNumber) {
-          feedbackEl.textContent = "Click \"New Game\" to start playing.";
-          feedbackEl.className = "feedback error";
+          setFeedback("startGamePrompt", "error");
           return;
         }
 
@@ -283,7 +452,7 @@
 
           if (!response.ok) {
             const { detail } = await response.json();
-            throw new Error(detail || "Unable to evaluate guess.");
+            throw new Error(detail || "guessError");
           }
 
           const result = await response.json();
@@ -291,24 +460,32 @@
           appendHistoryRow(guess, result.a, result.b);
 
           if (result.a === 4) {
-            feedbackEl.textContent = `🎉 Correct! You cracked the code in ${attemptCounter} attempts.`;
-            feedbackEl.className = "feedback success";
+            setFeedback("successMessage", "success", { attempts: attemptCounter });
           } else {
-            feedbackEl.textContent = `${result.a}A${result.b}B — keep going!`;
-            feedbackEl.className = "feedback";
+            setFeedback("guessContinue", "", { a: result.a, b: result.b });
           }
 
           guessInput.value = "";
           guessInput.focus();
         } catch (error) {
-          feedbackEl.textContent = error.message || "An unexpected error occurred.";
-          feedbackEl.className = "feedback error";
+          const messageKey = error && error.message;
+          if (messageKey && translations[currentLanguage][messageKey]) {
+            setFeedback(messageKey, "error");
+          } else {
+            setFeedback("genericError", "error");
+          }
         }
       });
 
       newGameButton.addEventListener("click", startNewGame);
 
-      // Start the first game as soon as the page loads.
+      languageSelect.addEventListener("change", () => {
+        currentLanguage = languageSelect.value;
+        applyTranslations();
+      });
+
+      applyTranslations();
+
       startNewGame();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add a language selector with Traditional Chinese defaults and English fallback text
- enlarge typography and spacing to improve readability for older users
- show the most recent guesses at the top of the history table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e908929ff0832890ee2a1367b1d8cc